### PR TITLE
Fix nginx error template parsing error

### DIFF
--- a/functions
+++ b/functions
@@ -8,7 +8,7 @@ source "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/functions"
 nginx_build_config() {
   declare desc="build nginx config to proxy posteio using sigil"
   local CONTAINER_ID="$(< "${POSTEIO_ROOT}/CONTAINER")"
-  local CONTAINER_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "${CONTAINER_ID}")
+  local CONTAINER_IP=$(docker inspect --format '{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}' "${CONTAINER_ID}")
   local DOMAIN_NAME="$(< "${POSTEIO_ROOT}/DOMAIN")"
   local SSL_IN_USE
   local NGINX_TEMPLATE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/nginx.conf.sigil"


### PR DESCRIPTION
I tried deploying to Dokku v0.37.5 and was getting this error:
```
template parsing error: template: :1:19: executing "" at <.NetworkSettings.IPAddress>: map has no entry for key "IPAddress"
```
